### PR TITLE
Overwrite nominal centroidal pose in initial state

### DIFF
--- a/include/MultiContactController/CentroidalManager.h
+++ b/include/MultiContactController/CentroidalManager.h
@@ -187,6 +187,20 @@ public:
   CentroidalManager(MultiContactController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig = {});
 
   /** \brief Reset.
+      \param constraintSetConfig mc_rtc configuration that has nominalCentroidalPose
+
+      This method should be called once when controller is reset.
+
+      An example of \p nominalCentroidalPoseConfig is as follows.
+      @code
+      configs:
+        nominalCentroidalPose:
+          translation: [0.0, 0.0, 0.966]
+      @endcode
+  */
+  virtual void reset(const mc_rtc::Configuration & nominalCentroidalPoseConfig);
+
+  /** \brief Reset.
 
       This method should be called once when controller is reset.
    */

--- a/include/MultiContactController/MultiContactController.h
+++ b/include/MultiContactController/MultiContactController.h
@@ -20,7 +20,8 @@ namespace MCC
 {
 class LimbManagerSet;
 class CentroidalManager;
-
+class PostureManager;
+  
 /** \brief Humanoid multi-contact motion controller. */
 struct MultiContactController : public mc_control::fsm::Controller
 {
@@ -85,6 +86,9 @@ public:
 
   //! Centroidal manager
   std::shared_ptr<CentroidalManager> centroidalManager_;
+
+  //! Posture manager
+  std::shared_ptr<PostureManager> postureManager_;
 
   //! Whether to enable manager update
   bool enableManagerUpdate_ = false;

--- a/include/MultiContactController/MultiContactController.h
+++ b/include/MultiContactController/MultiContactController.h
@@ -21,7 +21,7 @@ namespace MCC
 class LimbManagerSet;
 class CentroidalManager;
 class PostureManager;
-  
+
 /** \brief Humanoid multi-contact motion controller. */
 struct MultiContactController : public mc_control::fsm::Controller
 {

--- a/include/MultiContactController/PostureManager.h
+++ b/include/MultiContactController/PostureManager.h
@@ -20,8 +20,8 @@ class MultiContactController;
 class PostureManager
 {
 public:
-  typedef std::map<std::string, std::vector<double> > PostureMap;
-  
+  typedef std::map<std::string, std::vector<double>> PostureMap;
+
   /** \brief Configuration. */
   struct Configuration
   {
@@ -70,7 +70,7 @@ public:
       \param PostureMap map from joint names to joint angle
       \return whether nominalCentroidalPose is appended
   */
-  virtual bool appendNominalPosture(double t, const PostureMap &joints);
+  virtual bool appendNominalPosture(double t, const PostureMap & joints);
 
   /** \brief Get nominal posture.
       \param t time

--- a/include/MultiContactController/PostureManager.h
+++ b/include/MultiContactController/PostureManager.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <mc_rtc/gui/StateBuilder.h>
+#include <mc_rtc/log/Logger.h>
+
+namespace mc_rbdyn
+{
+class Robot;
+}
+
+namespace MCC
+{
+class MultiContactController;
+
+/** \brief Posture manager.
+
+    Posture manager calculates the target of robot posture.
+ */
+class PostureManager
+{
+public:
+  /** \brief Configuration. */
+  struct Configuration
+  {
+    //! Name
+    std::string name = "PostureManager";
+
+    /** \brief Load mc_rtc configuration. */
+    virtual void load(const mc_rtc::Configuration & mcRtcConfig);
+
+    /** \brief Add entries to the logger. */
+    virtual void addToLogger(const std::string & baseEntry, mc_rtc::Logger & logger);
+
+    /** \brief Remove entries from the logger. */
+    virtual void removeFromLogger(mc_rtc::Logger & logger);
+  };
+
+  /** \brief Reference data. */
+  struct RefData
+  {
+    //! Nominal posture
+    std::vector<std::vector<double>> posture;
+
+    /** \brief Reset. */
+    void reset();
+
+    /** \brief Add entries to the logger. */
+    virtual void addToLogger(const std::string & baseEntry, mc_rtc::Logger & logger);
+
+    /** \brief Remove entries from the logger. */
+    virtual void removeFromLogger(mc_rtc::Logger & logger);
+  };
+
+public:
+  /** \brief Constructor.
+      \param ctlPtr pointer to controller
+      \param mcRtcConfig mc_rtc configuration
+   */
+  PostureManager(MultiContactController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig = {});
+
+  /** \brief Reset.
+
+      This method should be called once when controller is reset.
+   */
+  virtual void reset();
+
+  /** \brief Update.
+
+      This method should be called once every control cycle.
+   */
+  virtual void update();
+
+  /** \brief Stop.
+
+      This method should be called once when stopping the controller.
+  */
+  virtual void stop();
+
+  /** \brief Const accessor to the configuration. */
+  virtual const Configuration & config();
+
+  /** \brief Add entries to the GUI. */
+  virtual void addToGUI(mc_rtc::gui::StateBuilder & gui);
+
+  /** \brief Remove entries from the GUI. */
+  virtual void removeFromGUI(mc_rtc::gui::StateBuilder & gui);
+
+  /** \brief Add entries to the logger. */
+  virtual void addToLogger(mc_rtc::Logger & logger);
+
+  /** \brief Remove entries from the logger. */
+  virtual void removeFromLogger(mc_rtc::Logger & logger);
+
+  /** \brief Append a nominal centroidal pose
+      \param t time
+      \param jointNames joint names to append
+      \param posture nominal postures to append
+      \return whether nominalCentroidalPose is appended
+  */
+  bool appendNominalPosture(double t, const std::vector<std::string> &jointNames,
+                            const std::vector<std::vector<double>> &posture);
+
+protected:
+  /** \brief Const accessor to the controller. */
+  inline const MultiContactController & ctl() const
+  {
+    return *ctlPtr_;
+  }
+
+  /** \brief Accessor to the controller. */
+  inline MultiContactController & ctl()
+  {
+    return *ctlPtr_;
+  }
+
+  /** \brief Accessor to the configuration. */
+  virtual Configuration & config();
+
+  /** \brief Calculate reference data.
+      \param t time
+   */
+  RefData calcRefData(double t) const;
+
+protected:
+  //! Pointer to controller
+  MultiContactController * ctlPtr_ = nullptr;
+
+  //! Reference data
+  RefData refData_;
+
+  //! Nominal posture list
+  std::map<double, std::vector<std::vector<double> > > nominalPostureList_;
+};
+} // namespace MCC

--- a/include/MultiContactController/PostureManager.h
+++ b/include/MultiContactController/PostureManager.h
@@ -2,6 +2,7 @@
 
 #include <mc_rtc/gui/StateBuilder.h>
 #include <mc_rtc/log/Logger.h>
+#include <mc_tasks/PostureTask.h>
 
 namespace mc_rbdyn
 {
@@ -19,6 +20,8 @@ class MultiContactController;
 class PostureManager
 {
 public:
+  typedef std::map<std::string, std::vector<double> > PostureMap;
+  
   /** \brief Configuration. */
   struct Configuration
   {
@@ -27,22 +30,6 @@ public:
 
     /** \brief Load mc_rtc configuration. */
     virtual void load(const mc_rtc::Configuration & mcRtcConfig);
-  };
-
-  /** \brief Reference data. */
-  struct RefData
-  {
-    //! Nominal posture
-    std::vector<std::vector<double>> posture;
-
-    /** \brief Reset. */
-    void reset();
-
-    /** \brief Add entries to the logger. */
-    virtual void addToLogger(const std::string & baseEntry, mc_rtc::Logger & logger);
-
-    /** \brief Remove entries from the logger. */
-    virtual void removeFromLogger(mc_rtc::Logger & logger);
   };
 
 public:
@@ -80,17 +67,15 @@ public:
 
   /** \brief Append a nominal centroidal pose
       \param t time
-      \param jointNames joint names to append
-      \param posture nominal postures to append
+      \param PostureMap map from joint names to joint angle
       \return whether nominalCentroidalPose is appended
   */
-  bool appendNominalPosture(double t, const std::vector<std::string> &jointNames,
-                            const std::vector<std::vector<double>> &posture);
+  virtual bool appendNominalPosture(double t, const PostureMap &joints);
 
   /** \brief Get nominal posture.
       \param t time
   */
-  std::vector<std::vector<double> > getNominalPosture(double t) const;
+  virtual PostureMap getNominalPosture(double t) const;
 
 protected:
   /** \brief Const accessor to the controller. */
@@ -111,11 +96,6 @@ protected:
     return config_;
   }
 
-  /** \brief Calculate reference data.
-      \param t time
-   */
-  RefData calcRefData(double t) const;
-
 protected:
   //! Configuration
   Configuration config_;
@@ -126,10 +106,7 @@ protected:
   //! Pointer to posture task in controller
   std::shared_ptr<mc_tasks::PostureTask> postureTask_;
 
-  //! Reference data
-  RefData refData_;
-
   //! Nominal posture list
-  std::map<double, std::vector<std::vector<double> > > nominalPostureList_;
+  std::map<double, PostureMap> nominalPostureList_;
 };
 } // namespace MCC

--- a/include/MultiContactController/PostureManager.h
+++ b/include/MultiContactController/PostureManager.h
@@ -27,12 +27,6 @@ public:
 
     /** \brief Load mc_rtc configuration. */
     virtual void load(const mc_rtc::Configuration & mcRtcConfig);
-
-    /** \brief Add entries to the logger. */
-    virtual void addToLogger(const std::string & baseEntry, mc_rtc::Logger & logger);
-
-    /** \brief Remove entries from the logger. */
-    virtual void removeFromLogger(mc_rtc::Logger & logger);
   };
 
   /** \brief Reference data. */
@@ -76,14 +70,7 @@ public:
   */
   virtual void stop();
 
-  /** \brief Const accessor to the configuration. */
-  virtual const Configuration & config();
-
-  /** \brief Add entries to the GUI. */
-  virtual void addToGUI(mc_rtc::gui::StateBuilder & gui);
-
-  /** \brief Remove entries from the GUI. */
-  virtual void removeFromGUI(mc_rtc::gui::StateBuilder & gui);
+  // TODO: implement GUI functions
 
   /** \brief Add entries to the logger. */
   virtual void addToLogger(mc_rtc::Logger & logger);
@@ -100,6 +87,11 @@ public:
   bool appendNominalPosture(double t, const std::vector<std::string> &jointNames,
                             const std::vector<std::vector<double>> &posture);
 
+  /** \brief Get nominal posture.
+      \param t time
+  */
+  std::vector<std::vector<double> > getNominalPosture(double t) const;
+
 protected:
   /** \brief Const accessor to the controller. */
   inline const MultiContactController & ctl() const
@@ -113,8 +105,11 @@ protected:
     return *ctlPtr_;
   }
 
-  /** \brief Accessor to the configuration. */
-  virtual Configuration & config();
+  /** \brief Const accessor to the configuration. */
+  inline virtual const Configuration & config() const
+  {
+    return config_;
+  }
 
   /** \brief Calculate reference data.
       \param t time
@@ -122,8 +117,14 @@ protected:
   RefData calcRefData(double t) const;
 
 protected:
+  //! Configuration
+  Configuration config_;
+
   //! Pointer to controller
   MultiContactController * ctlPtr_ = nullptr;
+
+  //! Pointer to posture task in controller
+  std::shared_ptr<mc_tasks::PostureTask> postureTask_;
 
   //! Reference data
   RefData refData_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(${CONTROLLER_NAME} SHARED
   LimbManager.cpp
   LimbManagerSet.cpp
   CentroidalManager.cpp
+  PostureManager.cpp
   swing/SwingTrajCubicSplineSimple.cpp
   centroidal/CentroidalManagerDDP.cpp
   centroidal/CentroidalManagerPC.cpp

--- a/src/CentroidalManager.cpp
+++ b/src/CentroidalManager.cpp
@@ -145,6 +145,15 @@ CentroidalManager::CentroidalManager(MultiContactController * ctlPtr, const mc_r
 {
 }
 
+void CentroidalManager::reset(const mc_rtc::Configuration & nominalCentroidalPoseConfig)
+{
+  if(nominalCentroidalPoseConfig.has("nominalCentroidalPose"))
+  {
+    nominalCentroidalPoseConfig("nominalCentroidalPose", config().nominalCentroidalPose);
+  }
+  reset();
+}
+
 void CentroidalManager::reset()
 {
   refData_.reset();

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -10,10 +10,10 @@
 
 #include <MultiContactController/LimbManagerSet.h>
 #include <MultiContactController/MultiContactController.h>
+#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/centroidal/CentroidalManagerDDP.h>
 #include <MultiContactController/centroidal/CentroidalManagerPC.h>
 #include <MultiContactController/centroidal/CentroidalManagerSRB.h>
-#include <MultiContactController/PostureManager.h>
 
 using namespace MCC;
 
@@ -132,7 +132,7 @@ MultiContactController::MultiContactController(mc_rbdyn::RobotModulePtr rm,
     mc_rtc::log::warning("[MultiContactController] PostureManager configuration is missing.");
     postureManager_ = std::make_shared<PostureManager>(this); // config is not mandatory
   }
-  
+
   // Load other configurations
   if(config().has("Contacts"))
   {

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -130,6 +130,7 @@ MultiContactController::MultiContactController(mc_rbdyn::RobotModulePtr rm,
   else
   {
     mc_rtc::log::warning("[MultiContactController] PostureManager configuration is missing.");
+    postureManager_ = std::make_shared<PostureManager>(this); // config is not mandatory
   }
   
   // Load other configurations

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -13,6 +13,7 @@
 #include <MultiContactController/centroidal/CentroidalManagerDDP.h>
 #include <MultiContactController/centroidal/CentroidalManagerPC.h>
 #include <MultiContactController/centroidal/CentroidalManagerSRB.h>
+#include <MultiContactController/PostureManager.h>
 
 using namespace MCC;
 
@@ -122,7 +123,15 @@ MultiContactController::MultiContactController(mc_rbdyn::RobotModulePtr rm,
   {
     mc_rtc::log::warning("[MultiContactController] CentroidalManager configuration is missing.");
   }
-
+  if(config().has("PostureManager"))
+  {
+    postureManager_ = std::make_shared<PostureManager>(this, config()("PostureManager"));
+  }
+  else
+  {
+    mc_rtc::log::warning("[MultiContactController] PostureManager configuration is missing.");
+  }
+  
   // Load other configurations
   if(config().has("Contacts"))
   {
@@ -163,6 +172,7 @@ bool MultiContactController::run()
     // Update managers
     limbManagerSet_->update();
     centroidalManager_->update();
+    postureManager_->update();
   }
 
   return mc_control::fsm::Controller::run();
@@ -184,6 +194,8 @@ void MultiContactController::stop()
   limbManagerSet_.reset();
   centroidalManager_->stop();
   centroidalManager_.reset();
+  postureManager_->stop();
+  postureManager_.reset();
 
   // Clean up anchor
   setDefaultAnchor();

--- a/src/PostureManager.cpp
+++ b/src/PostureManager.cpp
@@ -28,7 +28,9 @@ PostureManager::PostureManager(MultiContactController * ctlPtr, const mc_rtc::Co
 
 void PostureManager::reset()
 {
-  nominalPostureList_.clear();
+  // TODO: nominalPostureList_ should be cleared?
+  PostureManager::PostureMap postures; // empty map (= no modification for current PostureTask)
+  nominalPostureList_.emplace(ctl().t(), postures);
 }
 
 void PostureManager::update()
@@ -62,7 +64,7 @@ void PostureManager::removeFromLogger(mc_rtc::Logger & logger)
 
 PostureManager::PostureMap PostureManager::getNominalPosture(double t) const
 {
-  // if nominalPostureList_ is empty, return empty map
+  // if nominalPostureList_ is empty or specified past time, return empty map
   PostureManager::PostureMap postures;
   if (!nominalPostureList_.empty()) {
     auto it = nominalPostureList_.upper_bound(t);

--- a/src/PostureManager.cpp
+++ b/src/PostureManager.cpp
@@ -1,0 +1,174 @@
+#include <cmath>
+
+#include <mc_rtc/gui/ArrayInput.h>
+#include <mc_rtc/gui/Checkbox.h>
+#include <mc_rtc/gui/Ellipsoid.h>
+#include <mc_rtc/gui/NumberInput.h>
+#include <mc_tasks/PostureTask.h>
+
+#include <MultiContactController/PostureManager.h>
+#include <MultiContactController/MultiContactController.h>
+
+using namespace MCC;
+
+void PostureManager::Configuration::load(const mc_rtc::Configuration & mcRtcConfig)
+{
+  mcRtcConfig("name", name);
+}
+
+void PostureManager::Configuration::addToLogger(const std::string & baseEntry, mc_rtc::Logger & logger)
+{
+}
+
+void PostureManager::Configuration::removeFromLogger(mc_rtc::Logger & logger)
+{
+  logger.removeLogEntries(this);
+}
+
+void PostureManager::RefData::reset()
+{
+  *this = RefData();
+}
+
+void PostureManager::RefData::addToLogger(const std::string & baseEntry, mc_rtc::Logger & logger)
+{
+  MC_RTC_LOG_HELPER(baseEntry + "_posture_ref", posture);
+}
+
+void PostureManager::RefData::removeFromLogger(mc_rtc::Logger & logger)
+{
+  logger.removeLogEntries(this);
+}
+
+PostureManager::PostureManager(MultiContactController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig)
+  : ctlPtr_(ctlPtr)
+{
+}
+
+void PostureManager::reset()
+{
+  refData_.reset();
+
+  auto postureTask = ctl().getPostureTask(ctl().robot().name());
+  if (postureTask == nullptr) {
+    mc_rtc::log::error("[PostureManager] PostureTask does not exist");
+    return;
+  }
+  nominalPostureList_.emplace(ctl().t(), postureTask->posture());
+}
+
+void PostureManager::update()
+{
+  // Set data
+  refData_ = calcRefData(ctl().t());
+  
+  auto postureTask = ctl().getPostureTask(ctl().robot().name());
+  postureTask->posture(refData_.posture());
+
+  // TODO: update postureTask->refVel and postureTask->refAcc
+}
+
+void PostureManager::stop()
+{
+  removeFromGUI(*ctl().gui());
+  removeFromLogger(ctl().logger());
+}
+
+void PostureManager::addToGUI(mc_rtc::gui::StateBuilder & gui)
+{
+}
+
+void PostureManager::removeFromGUI(mc_rtc::gui::StateBuilder & gui)
+{
+  // gui.removeCategory({ctl().name(), config().name});
+}
+
+void PostureManager::addToLogger(mc_rtc::Logger & logger)
+{
+  config().addToLogger(config().name + "_Config", logger);
+  refData_.addToLogger(config().name + "_Data", logger);
+
+  logger.addLogEntry(config().name + "_nominalPosture", this,
+                     [this]() { return getNominalPosture(ctl().t()); });
+}
+
+void PostureManager::removeFromLogger(mc_rtc::Logger & logger)
+{
+  config().removeFromLogger(logger);
+  refData_.removeFromLogger(logger);
+
+  logger.removeLogEntries(this);
+}
+
+std::vector<std::vector<double> > PostureManager::getNominalPosture(double t) const
+{
+  auto it = nominalPostureList_.upper_bound(t);
+  if(it == nominalPostureList_.begin())
+  {
+    mc_rtc::log::error_and_throw(
+        "[PostureManager] Past time is specified in {}. specified time: {}, current time: {}",
+        __func__, t, ctl().t());
+  }
+  it--;
+  return it->second;
+}
+
+bool PostureManager::appendNominalPosture(double t, const std::vector<std::string> &jointNames,
+                                          const std::vector<std::vector<double>> &posture)
+{
+  if (t < ctl().t()) {
+    mc_rtc::log::error("[PostureManager] Ignore a nominal posture with past time: {} < {}", t, ctl().t());
+    return false;
+  }
+
+  if (jointNames.size() != posture.size()) {
+      mc_rtc::log::error("[PostureManager] size of jointNames({}) and posture({}) are different",
+                         jointNames.size(), posture.size());
+      return false;
+  }
+
+  std::vector<std::vector<double> > refPosture;
+  if (!nominalPostureList_.empty()) {
+    double lastTime = nominalPostureList_.rbegin()->first;
+    if (t < lastTime) {
+      mc_rtc::log::error("[PostureManager] Ignore a nominal posture earlier than the last one: {} < {}",
+                         t, lastTime);
+      return false;
+    }
+    std::vector<std::vector<double> > lastPosture = nominalPostureList_.rbegin()->second;
+    std::copy(lastPosture.begin(), lastPosture.rbegin()->second.end(), std::back_inserter(refPosture));
+  } else {
+    std::vector<std::vector<double> > postureInTask = ctl().getPostureTask(ctl().robot().name())->posture();
+    std::copy(postureInTask.begin(), postureInTask.end(), std::back_inserter(refPosture));
+  }
+
+  for (int i = 0; i < jointNames.size(); i++) {
+    std::string jn = jointNames[i];
+    int jIndex = ctl().robot().mb().jointIndexByName(jn);
+    if (jIndex < 0) {
+      mc_rtc::log::error("[PostureManager] Ignore joint {} which does not exist", jn);
+      continue;
+    }
+    if (jIndex < refPosture.size()) {
+      refPosture[jIndex] = posture[i];
+    } else {
+      mc_rtc::log::error("[PostureManager] Ignore joint index {} for {} which exceeds size of posture ({})",
+                         jIndex, jn, refPosture.size());
+      continue;
+    }
+  }
+
+  nominalPostureList_.emplace(t, refPosture);
+  return true;
+}
+
+PostureManager::RefData PostureManager::calcRefData(double t) const
+{
+  RefData refData;
+
+  // TODO: should be interpolated?
+  std::vector<std::vector<double> > nominalPosture = getNominalPosture(t);
+  refData.nominalPosture = nominalPosture;
+
+  return refData;
+}

--- a/src/PostureManager.cpp
+++ b/src/PostureManager.cpp
@@ -6,8 +6,8 @@
 #include <mc_rtc/gui/NumberInput.h>
 #include <mc_tasks/PostureTask.h>
 
-#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/MultiContactController.h>
+#include <MultiContactController/PostureManager.h>
 
 using namespace MCC;
 
@@ -17,10 +17,11 @@ void PostureManager::Configuration::load(const mc_rtc::Configuration & mcRtcConf
 }
 
 PostureManager::PostureManager(MultiContactController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig)
-  : ctlPtr_(ctlPtr)
+: ctlPtr_(ctlPtr)
 {
   postureTask_ = ctl().getPostureTask(ctl().robot().name());
-  if (postureTask_ == nullptr) {
+  if(postureTask_ == nullptr)
+  {
     mc_rtc::log::error_and_throw("[PostureManager] PostureTask does not exist");
   }
   config_.load(mcRtcConfig);
@@ -50,10 +51,12 @@ void PostureManager::stop()
 void PostureManager::addToLogger(mc_rtc::Logger & logger)
 {
   auto q = postureTask_->posture();
-  for (unsigned int i = 0; i < q.size(); i++) {
-    if (q[i].size() == 1) { // only consider 1DoF joints (posture includes Root and fixed joints)
+  for(unsigned int i = 0; i < q.size(); i++)
+  {
+    if(q[i].size() == 1)
+    { // only consider 1DoF joints (posture includes Root and fixed joints)
       std::string jname = ctl().robot().mb().joint(i).name();
-      std::replace(jname.begin(), jname.end(), '_', '-'); // underbar creates a new layer 
+      std::replace(jname.begin(), jname.end(), '_', '-'); // underbar creates a new layer
       logger.addLogEntry(config().name + "_nominalPosture_" + jname, this,
                          [this, i]() { return postureTask_->posture()[i][0]; });
     }
@@ -69,12 +72,14 @@ PostureManager::PostureMap PostureManager::getNominalPosture(double t) const
 {
   // if nominalPostureList_ is empty or specified past time, return empty map
   PostureManager::PostureMap postures;
-  if (!nominalPostureList_.empty()) {
+  if(!nominalPostureList_.empty())
+  {
     auto it = nominalPostureList_.upper_bound(t);
-    if(it == nominalPostureList_.begin()) {
+    if(it == nominalPostureList_.begin())
+    {
       mc_rtc::log::error_and_throw(
-        "[PostureManager] Past time is specified in {}. specified time: {}, current time: {}",
-        __func__, t, ctl().t());
+          "[PostureManager] Past time is specified in {}. specified time: {}, current time: {}", __func__, t,
+          ctl().t());
     }
     it--;
     postures = it->second;
@@ -82,9 +87,10 @@ PostureManager::PostureMap PostureManager::getNominalPosture(double t) const
   return postures;
 }
 
-bool PostureManager::appendNominalPosture(double t, const PostureManager::PostureMap &postures)
+bool PostureManager::appendNominalPosture(double t, const PostureManager::PostureMap & postures)
 {
-  if (t < ctl().t()) {
+  if(t < ctl().t())
+  {
     mc_rtc::log::error("[PostureManager] Ignore a nominal posture with past time: {} < {}", t, ctl().t());
     return false;
   }

--- a/src/PostureManager.cpp
+++ b/src/PostureManager.cpp
@@ -49,12 +49,15 @@ void PostureManager::stop()
 
 void PostureManager::addToLogger(mc_rtc::Logger & logger)
 {
-  std::vector<double> flatten;
-  for (auto p : postureTask_->posture()) {
-    flatten.insert(flatten.end(), p.begin(), p.end());
+  auto q = postureTask_->posture();
+  for (unsigned int i = 0; i < q.size(); i++) {
+    if (q[i].size() == 1) { // only consider 1DoF joints (posture includes Root and fixed joints)
+      std::string jname = ctl().robot().mb().joint(i).name();
+      std::replace(jname.begin(), jname.end(), '_', '-'); // underbar creates a new layer 
+      logger.addLogEntry(config().name + "_nominalPosture_" + jname, this,
+                         [this, i]() { return postureTask_->posture()[i][0]; });
+    }
   }
-  logger.addLogEntry(config().name + "_nominalPosture", this,
-                     [flatten]() { return flatten; });
 }
 
 void PostureManager::removeFromLogger(mc_rtc::Logger & logger)

--- a/src/PostureManager.cpp
+++ b/src/PostureManager.cpp
@@ -16,26 +16,6 @@ void PostureManager::Configuration::load(const mc_rtc::Configuration & mcRtcConf
   mcRtcConfig("name", name);
 }
 
-void PostureManager::RefData::reset()
-{
-  *this = RefData();
-}
-
-void PostureManager::RefData::addToLogger(const std::string & baseEntry, mc_rtc::Logger & logger)
-{
-  std::vector<double> flatten;
-  for (auto p : posture) {
-    flatten.insert(flatten.end(), p.begin(), p.end());
-  }
-  logger.addLogEntry(baseEntry + "_nominalPosture", this,
-                     [flatten]() { return flatten; });
-}
-
-void PostureManager::RefData::removeFromLogger(mc_rtc::Logger & logger)
-{
-  logger.removeLogEntries(this);
-}
-
 PostureManager::PostureManager(MultiContactController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig)
   : ctlPtr_(ctlPtr)
 {
@@ -48,15 +28,14 @@ PostureManager::PostureManager(MultiContactController * ctlPtr, const mc_rtc::Co
 
 void PostureManager::reset()
 {
-  refData_.reset();
-  nominalPostureList_.emplace(ctl().t(), postureTask_->posture());
+  nominalPostureList_.clear();
 }
 
 void PostureManager::update()
 {
   // Set data
-  refData_ = calcRefData(ctl().t());
-  postureTask_->posture(refData_.posture);
+  PostureManager::PostureMap ref = getNominalPosture(ctl().t());
+  postureTask_->target(ref); // this function will do nothing if ref is empty
 
   // TODO: update postureTask_->refVel and postureTask_->refAcc
 }
@@ -68,21 +47,24 @@ void PostureManager::stop()
 
 void PostureManager::addToLogger(mc_rtc::Logger & logger)
 {
-  refData_.addToLogger(config().name + "_Data", logger);
+  std::vector<double> flatten;
+  for (auto p : postureTask_->posture()) {
+    flatten.insert(flatten.end(), p.begin(), p.end());
+  }
+  logger.addLogEntry(config().name + "_nominalPosture", this,
+                     [flatten]() { return flatten; });
 }
 
 void PostureManager::removeFromLogger(mc_rtc::Logger & logger)
 {
-  refData_.removeFromLogger(logger);
   logger.removeLogEntries(this);
 }
 
-std::vector<std::vector<double> > PostureManager::getNominalPosture(double t) const
+PostureManager::PostureMap PostureManager::getNominalPosture(double t) const
 {
-  if (nominalPostureList_.empty()) {
-    // if nominalPostureList_ is not defined, return current posture task
-    return postureTask_->posture();
-  } else {
+  // if nominalPostureList_ is empty, return empty map
+  PostureManager::PostureMap postures;
+  if (!nominalPostureList_.empty()) {
     auto it = nominalPostureList_.upper_bound(t);
     if(it == nominalPostureList_.begin()) {
       mc_rtc::log::error_and_throw(
@@ -90,65 +72,17 @@ std::vector<std::vector<double> > PostureManager::getNominalPosture(double t) co
         __func__, t, ctl().t());
     }
     it--;
-    return it->second;
+    postures = it->second;
   }
+  return postures;
 }
 
-bool PostureManager::appendNominalPosture(double t, const std::vector<std::string> &jointNames,
-                                          const std::vector<std::vector<double>> &posture)
+bool PostureManager::appendNominalPosture(double t, const PostureManager::PostureMap &postures)
 {
   if (t < ctl().t()) {
     mc_rtc::log::error("[PostureManager] Ignore a nominal posture with past time: {} < {}", t, ctl().t());
     return false;
   }
-
-  if (jointNames.size() != posture.size()) {
-      mc_rtc::log::error("[PostureManager] size of jointNames({}) and posture({}) are different",
-                         jointNames.size(), posture.size());
-      return false;
-  }
-
-  std::vector<std::vector<double> > refPosture, lastPosture;
-  if (!nominalPostureList_.empty()) {
-    double lastTime = nominalPostureList_.rbegin()->first;
-    if (t < lastTime) {
-      mc_rtc::log::error("[PostureManager] Ignore a nominal posture earlier than the last one: {} < {}",
-                         t, lastTime);
-      return false;
-    }
-    lastPosture = nominalPostureList_.rbegin()->second;
-  } else {
-    lastPosture = postureTask_->posture();
-  }
-  std::copy(lastPosture.begin(), lastPosture.end(), std::back_inserter(refPosture));
-
-  for (unsigned int i = 0; i < jointNames.size(); i++) {
-    std::string jn = jointNames[i];
-    int jIndex = ctl().robot().mb().jointIndexByName(jn);
-    if (jIndex < 0) {
-      mc_rtc::log::error("[PostureManager] Ignore joint {} which does not exist", jn);
-      continue;
-    }
-    if (static_cast<size_t>(jIndex) < refPosture.size()) {
-      refPosture[jIndex] = posture[i];
-    } else {
-      mc_rtc::log::error("[PostureManager] Ignore joint index {} for {} which exceeds size of posture ({})",
-                         jIndex, jn, refPosture.size());
-      continue;
-    }
-  }
-
-  nominalPostureList_.emplace(t, refPosture);
+  nominalPostureList_.emplace(t, postures);
   return true;
-}
-
-PostureManager::RefData PostureManager::calcRefData(double t) const
-{
-  RefData refData;
-
-  // TODO: should be interpolated?
-  std::vector<std::vector<double> > nominalPosture = getNominalPosture(t);
-  refData.posture = nominalPosture;
-
-  return refData;
 }

--- a/src/PostureManager.cpp
+++ b/src/PostureManager.cpp
@@ -28,7 +28,7 @@ PostureManager::PostureManager(MultiContactController * ctlPtr, const mc_rtc::Co
 
 void PostureManager::reset()
 {
-  // TODO: nominalPostureList_ should be cleared?
+  nominalPostureList_.clear();
   PostureManager::PostureMap postures; // empty map (= no modification for current PostureTask)
   nominalPostureList_.emplace(ctl().t(), postures);
 }

--- a/src/states/ConfigMotionState.cpp
+++ b/src/states/ConfigMotionState.cpp
@@ -4,8 +4,8 @@
 
 #include <MultiContactController/CentroidalManager.h>
 #include <MultiContactController/LimbManagerSet.h>
-#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/MultiContactController.h>
+#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/states/ConfigMotionState.h>
 
 using namespace MCC;

--- a/src/states/ConfigMotionState.cpp
+++ b/src/states/ConfigMotionState.cpp
@@ -4,6 +4,7 @@
 
 #include <MultiContactController/CentroidalManager.h>
 #include <MultiContactController/LimbManagerSet.h>
+#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/MultiContactController.h>
 #include <MultiContactController/states/ConfigMotionState.h>
 
@@ -54,6 +55,21 @@ void ConfigMotionState::start(mc_control::fsm::Controller & _ctl)
       }
       ctl().centroidalManager_->appendNominalCentroidalPose(
           time, static_cast<sva::PTransformd>(nominalCentroidalPoseConfig("pose")));
+    }
+  }
+
+  // Send nominal posture
+  if(config_.has("configs") && config_("configs").has("nominalPostureList"))
+  {
+    for(const auto & nominalPostureConfig : config_("configs")("nominalPostureList"))
+    {
+      double time = nominalPostureConfig("time");
+      if(!std::isnan(baseTime))
+      {
+        time += baseTime;
+      }
+      PostureManager::PostureMap refPosture = nominalPostureConfig("target");
+      ctl().postureManager_->appendNominalPosture(time, refPosture);
     }
   }
 

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -69,6 +69,7 @@ bool InitialState::run(mc_control::fsm::Controller &)
     ctl().limbManagerSet_->reset(initialContactsConfig);
     ctl().centroidalManager_->reset();
     ctl().enableManagerUpdate_ = true;
+    ctl().postureManager_->reset();
 
     // Setup anchor frame
     ctl().centroidalManager_->setAnchorFrame();

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -67,9 +67,18 @@ bool InitialState::run(mc_control::fsm::Controller &)
       initialContactsConfig = config_("configs")("initialContacts");
     }
     ctl().limbManagerSet_->reset(initialContactsConfig);
-    ctl().centroidalManager_->reset();
-    ctl().enableManagerUpdate_ = true;
+
+    if(config_.has("configs"))
+    {
+      // Overwrite nominalCetnroidalPose if config_("configs")("nominalCentroidalPose") exists
+      ctl().centroidalManager_->reset(config_("configs"));
+    }
+    else
+    {
+      ctl().centroidalManager_->reset();
+    }
     ctl().postureManager_->reset();
+    ctl().enableManagerUpdate_ = true;
 
     // Setup anchor frame
     ctl().centroidalManager_->setAnchorFrame();

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -5,6 +5,7 @@
 
 #include <MultiContactController/CentroidalManager.h>
 #include <MultiContactController/LimbManagerSet.h>
+#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/MultiContactController.h>
 #include <MultiContactController/states/InitialState.h>
 
@@ -94,6 +95,7 @@ bool InitialState::run(mc_control::fsm::Controller &)
     // it is safe to call the update method once and then add the logger
     ctl().limbManagerSet_->addToLogger(ctl().logger());
     ctl().centroidalManager_->addToLogger(ctl().logger());
+    ctl().postureManager_->addToLogger(ctl().logger());
   }
 
   // Interpolate task stiffness

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -5,8 +5,8 @@
 
 #include <MultiContactController/CentroidalManager.h>
 #include <MultiContactController/LimbManagerSet.h>
-#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/MultiContactController.h>
+#include <MultiContactController/PostureManager.h>
 #include <MultiContactController/states/InitialState.h>
 
 using namespace MCC;


### PR DESCRIPTION
Problem:
When I want to start the MCC from the different configuration from the default nominalCentroidalPose defined in the yaml for the robot, it fails to start because centraoidalManager is initialized using the default nominalCetnraoidalPose.

Solution:
Add a new reset function of CentroidalManager to overwrite nominalCentroidalPose in `centroidalManager_->config()` by nominalCentroidalPose in the configs of MCC::Initial. 

NOTE: This PR includes https://github.com/isri-aist/MultiContactController/pull/7.