### PR TITLE
Add com and collision configs in init state

### DIFF
--- a/include/MultiContactController/CentroidalManager.h
+++ b/include/MultiContactController/CentroidalManager.h
@@ -187,6 +187,20 @@ public:
   CentroidalManager(MultiContactController * ctlPtr, const mc_rtc::Configuration & mcRtcConfig = {});
 
   /** \brief Reset.
+      \param constraintSetConfig mc_rtc configuration that has nominalCentroidalPose
+
+      This method should be called once when controller is reset.
+
+      An example of \p nominalCentroidalPoseConfig is as follows.
+      @code
+      configs:
+        nominalCentroidalPose:
+          translation: [0.0, 0.0, 0.966]
+      @endcode
+  */
+  virtual void reset(const mc_rtc::Configuration & nominalCentroidalPoseConfig);
+
+  /** \brief Reset.
 
       This method should be called once when controller is reset.
    */

--- a/src/CentroidalManager.cpp
+++ b/src/CentroidalManager.cpp
@@ -145,6 +145,15 @@ CentroidalManager::CentroidalManager(MultiContactController * ctlPtr, const mc_r
 {
 }
 
+void CentroidalManager::reset(const mc_rtc::Configuration & nominalCentroidalPoseConfig)
+{
+  if(nominalCentroidalPoseConfig.has("nominalCentroidalPose"))
+  {
+    nominalCentroidalPoseConfig("nominalCentroidalPose", config().nominalCentroidalPose);
+  }
+  reset();
+}
+
 void CentroidalManager::reset()
 {
   refData_.reset();

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -77,6 +77,32 @@ bool InitialState::run(mc_control::fsm::Controller &)
     }
     ctl().enableManagerUpdate_ = true;
 
+    // Setup collisions
+    if(config_.has("configs") && config_("configs").has("collisionConfigList"))
+    {
+      for(const auto & collisionConfig : config_("configs")("collisionConfigList"))
+      {
+        std::string r1 = collisionConfig("r1");
+        std::string r2 = collisionConfig("r2", std::as_const(r1));
+        if(collisionConfig("type") == "Add")
+        {
+          ctl().addCollisions(r1, r2, static_cast<std::vector<mc_rbdyn::Collision>>(collisionConfig("collisions")));
+        }
+        else
+        {
+          if(collisionConfig.has("collisions"))
+          {
+            ctl().removeCollisions(r1, r2,
+                                   static_cast<std::vector<mc_rbdyn::Collision>>(collisionConfig("collisions")));
+          }
+          else
+          {
+            ctl().removeCollisions(r1, r2);
+          }
+        }
+      }
+    }
+
     // Setup anchor frame
     ctl().centroidalManager_->setAnchorFrame();
 

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -66,7 +66,15 @@ bool InitialState::run(mc_control::fsm::Controller &)
       initialContactsConfig = config_("configs")("initialContacts");
     }
     ctl().limbManagerSet_->reset(initialContactsConfig);
-    ctl().centroidalManager_->reset();
+    if(config_.has("configs"))
+    {
+      // Overwrite nominalCetnroidalPose if config_("configs")("nominalCentroidalPose") exists
+      ctl().centroidalManager_->reset(config_("configs"));
+    }
+    else
+    {
+      ctl().centroidalManager_->reset();
+    }
     ctl().enableManagerUpdate_ = true;
 
     // Setup anchor frame


### PR DESCRIPTION
Problem:
When I want to start the MCC from the different configuration, I have the following problems.
- The robot fails to start because centraoidalManager is initialized using the default nominalCetnraoidalPose.
- The posture of the robot cannot consider collisions because the collision constraints are not set

Solution:
- Add a new reset function of CentroidalManager to overwrite nominalCentroidalPose in centroidalManager_->config() by nominalCentroidalPose in the configs of MCC::Initial.
- Set collision pairs defined as collisionConfigList in the configs of MCC::Initial.
