### PR TITLE
Do not reset shared_ptrs to prevent SEGV when changing controllers

### DIFF
--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -181,9 +181,7 @@ void MultiContactController::stop()
 
   // Clean up managers
   limbManagerSet_->stop();
-  limbManagerSet_.reset();
   centroidalManager_->stop();
-  centroidalManager_.reset();
 
   // Clean up anchor
   setDefaultAnchor();


### PR DESCRIPTION
Problem: 
When I change controller from MCC to other controllers and go back to MCC, mc_rtc raises SEGV because stop() function reset shared_ptrs for managers. 

Solution:
Do not reset managers in reset() function. The old configurations will be removed by calling their reset() functions in MCC::Initial.  