### PR TITLE
Init base pose from datastore

### DIFF
--- a/include/MultiContactController/MultiContactController.h
+++ b/include/MultiContactController/MultiContactController.h
@@ -89,6 +89,9 @@ public:
   //! Whether to enable manager update
   bool enableManagerUpdate_ = false;
 
+  //! Whether to save last base pose when stopping this controller
+  bool saveLastBasePose_ = false;
+
 protected:
   //! Controller name
   std::string name_ = "MCC";

--- a/include/MultiContactController/states/ConfigMotionState.h
+++ b/include/MultiContactController/states/ConfigMotionState.h
@@ -25,5 +25,11 @@ protected:
 
   //! Task configuration list
   std::multimap<double, mc_rtc::Configuration> taskConfigList_;
+
+  //! Option to select whether this state should wait for finishing swing motion or not
+  bool exitWhenLimbSwingFinished_ = false;
+
+  //! Option to save the last pose in datastore for the other motion
+  bool saveLastBasePose_ = false;
 };
 } // namespace MCC

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -130,7 +130,20 @@ MultiContactController::MultiContactController(mc_rbdyn::RobotModulePtr rm,
     ForceColl::SurfaceContact::loadVerticesMap(contactsConfig("Surface", mc_rtc::Configuration{}));
     ForceColl::GraspContact::loadVerticesMap(contactsConfig("Grasp", mc_rtc::Configuration{}));
   }
-
+  if(config_.has("basePose"))
+  {
+    // Initialize basePose from yaml only once
+    auto configPose = config_("basePose").operator sva::PTransformd();
+    auto & ds = datastore();
+    if(!ds.has("MCC::ResetBasePose"))
+    {
+      ds.make<sva::PTransformd>("MCC::ResetBasePose", configPose);
+    }
+    else
+    {
+      ds.assign<sva::PTransformd>("MCC::ResetBasePose", configPose);
+    }
+  }
   if(config().has("saveLastBasePose"))
   {
     saveLastBasePose_ = config()("saveLastBasePose");
@@ -146,21 +159,13 @@ void MultiContactController::reset(const mc_control::ControllerResetData & reset
 {
   mc_control::fsm::Controller::reset(resetData);
 
-  if(datastore().has("MCC::LastBasePose"))
+  if(datastore().has("MCC::ResetBasePose"))
   {
-    const auto & pose = datastore().get<sva::PTransformd>("MCC::LastBasePose");
+    const auto & pose = datastore().get<sva::PTransformd>("MCC::ResetBasePose");
     robot().posW(pose);
     realRobot().posW(pose);
-    datastore().remove("MCC::LastBasePose"); // avoid accidental reuse of old base pose
-  }
-  else
-  {
-    if(config_.has("basePose"))
-    {
-      auto pose = config_("basePose").operator sva::PTransformd();
-      robot().posW(pose);
-      realRobot().posW(pose);
-    }
+    mc_rtc::log::info("[MultiContactController] update basePose:\ntrans={}\nrot=\n{}",
+                      pose.translation().transpose(), pose.rotation());
   }
 
   enableManagerUpdate_ = false;
@@ -210,17 +215,17 @@ void MultiContactController::stop()
   // Clean up anchor
   setDefaultAnchor();
 
-  // Save last base pose to change controllers
+  // Save last base pose to keep base pose after changing controllers
   if(saveLastBasePose_)
   {
     auto & ds = datastore();
-    if(!ds.has("MCC::LastBasePose"))
+    if(!ds.has("MCC::ResetBasePose"))
     {
-      ds.make<sva::PTransformd>("MCC::LastBasePose", robot().posW());
+      ds.make<sva::PTransformd>("MCC::ResetBasePose", robot().posW());
     }
     else
     {
-      ds.assign<sva::PTransformd>("MCC::LastBasePose", robot().posW());
+      ds.assign<sva::PTransformd>("MCC::ResetBasePose", robot().posW());
     }
   }
 

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -141,6 +141,22 @@ void MultiContactController::reset(const mc_control::ControllerResetData & reset
 {
   mc_control::fsm::Controller::reset(resetData);
 
+  if(datastore().has("MCC::LastBasePose"))
+  {
+    const auto & pose = datastore().get<sva::PTransformd>("MCC::LastBasePose");
+    robot().posW(pose);
+    realRobot().posW(pose);
+  }
+  else
+  {
+    if(config_.has("basePose"))
+    {
+      auto pose = config_("basePose").operator sva::PTransformd();
+      robot().posW(pose);
+      realRobot().posW(pose);
+    }
+  }
+
   enableManagerUpdate_ = false;
 
   // Print message to set priority

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -159,6 +159,8 @@ void MultiContactController::reset(const mc_control::ControllerResetData & reset
 {
   mc_control::fsm::Controller::reset(resetData);
 
+  posture_tasks_[robot().name()]->reset();
+
   if(datastore().has("MCC::ResetBasePose"))
   {
     const auto & pose = datastore().get<sva::PTransformd>("MCC::ResetBasePose");

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -166,8 +166,8 @@ void MultiContactController::reset(const mc_control::ControllerResetData & reset
     const auto & pose = datastore().get<sva::PTransformd>("MCC::ResetBasePose");
     robot().posW(pose);
     realRobot().posW(pose);
-    mc_rtc::log::info("[MultiContactController] update basePose:\ntrans={}\nrot=\n{}",
-                      pose.translation().transpose(), pose.rotation());
+    mc_rtc::log::info("[MultiContactController] update basePose:\ntrans={}\nrot=\n{}", pose.translation().transpose(),
+                      pose.rotation());
   }
 
   enableManagerUpdate_ = false;

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -131,6 +131,11 @@ MultiContactController::MultiContactController(mc_rbdyn::RobotModulePtr rm,
     ForceColl::GraspContact::loadVerticesMap(contactsConfig("Grasp", mc_rtc::Configuration{}));
   }
 
+  if(config().has("saveLastBasePose"))
+  {
+    saveLastBasePose_ = config()("saveLastBasePose");
+  }
+
   // Setup anchor
   setDefaultAnchor();
 
@@ -146,7 +151,7 @@ void MultiContactController::reset(const mc_control::ControllerResetData & reset
     const auto & pose = datastore().get<sva::PTransformd>("MCC::LastBasePose");
     robot().posW(pose);
     realRobot().posW(pose);
-    ctl().datastore().remove("MCC::LastBasePose"); // avoid accidental reuse of old base pose
+    datastore().remove("MCC::LastBasePose"); // avoid accidental reuse of old base pose
   }
   else
   {
@@ -204,6 +209,20 @@ void MultiContactController::stop()
 
   // Clean up anchor
   setDefaultAnchor();
+
+  // Save last base pose to change controllers
+  if(saveLastBasePose_)
+  {
+    auto & ds = datastore();
+    if(!ds.has("MCC::LastBasePose"))
+    {
+      ds.make<sva::PTransformd>("MCC::LastBasePose", robot().posW());
+    }
+    else
+    {
+      ds.assign<sva::PTransformd>("MCC::LastBasePose", robot().posW());
+    }
+  }
 
   mc_control::fsm::Controller::stop();
 }

--- a/src/MultiContactController.cpp
+++ b/src/MultiContactController.cpp
@@ -146,6 +146,7 @@ void MultiContactController::reset(const mc_control::ControllerResetData & reset
     const auto & pose = datastore().get<sva::PTransformd>("MCC::LastBasePose");
     robot().posW(pose);
     realRobot().posW(pose);
+    ctl().datastore().remove("MCC::LastBasePose"); // avoid accidental reuse of old base pose
   }
   else
   {

--- a/src/states/ConfigMotionState.cpp
+++ b/src/states/ConfigMotionState.cpp
@@ -174,20 +174,6 @@ bool ConfigMotionState::run(mc_control::fsm::Controller &)
   return !ctl().limbManagerSet_->contactCommandStacked() && taskConfigList_.empty() && collisionConfigList_.empty();
 }
 
-void ConfigMotionState::teardown(mc_control::fsm::Controller &)
-{
-  if(saveLastBasePose_)
-  {
-    auto & ds = ctl().datastore();
-    if(!ds.has("MCC::LastBasePose"))
-    {
-      ds.make<sva::PTransformd>("MCC::LastBasePose", ctl().robot().posW());
-    }
-    else
-    {
-      ds.assign<sva::PTransformd>("MCC::LastBasePose", ctl().robot().posW());
-    }
-  }
-}
+void ConfigMotionState::teardown(mc_control::fsm::Controller &) {}
 
 EXPORT_SINGLE_STATE("MCC::ConfigMotion", ConfigMotionState)

--- a/src/states/ConfigMotionState.cpp
+++ b/src/states/ConfigMotionState.cpp
@@ -89,6 +89,16 @@ void ConfigMotionState::start(mc_control::fsm::Controller & _ctl)
     }
   }
 
+  // Set option to wait for finishing swing motion
+  if(config_.has("configs") && config_("configs").has("exitWhenLimbSwingFinished"))
+  {
+    exitWhenLimbSwingFinished_ = static_cast<bool>(config_("configs")("exitWhenLimbSwingFinished"));
+  }
+  if(config_.has("configs") && config_("configs").has("saveLastBasePose"))
+  {
+    saveLastBasePose_ = static_cast<bool>(config_("configs")("saveLastBasePose"));
+  }
+
   output("OK");
 }
 
@@ -164,6 +174,20 @@ bool ConfigMotionState::run(mc_control::fsm::Controller &)
   return !ctl().limbManagerSet_->contactCommandStacked() && taskConfigList_.empty() && collisionConfigList_.empty();
 }
 
-void ConfigMotionState::teardown(mc_control::fsm::Controller &) {}
+void ConfigMotionState::teardown(mc_control::fsm::Controller &)
+{
+  if(saveLastBasePose_)
+  {
+    auto & ds = ctl().datastore();
+    if(!ds.has("MCC::LastBasePose"))
+    {
+      ds.make<sva::PTransformd>("MCC::LastBasePose", ctl().robot().posW());
+    }
+    else
+    {
+      ds.assign<sva::PTransformd>("MCC::LastBasePose", ctl().robot().posW());
+    }
+  }
+}
 
 EXPORT_SINGLE_STATE("MCC::ConfigMotion", ConfigMotionState)

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -60,11 +60,17 @@ bool InitialState::run(mc_control::fsm::Controller &)
         std::map<double, double>{{ctl().t(), 0.0}, {ctl().t() + stiffnessInterpDuration, 1.0}});
 
     // Initialize base pose of the robot
-    if (config_.has("configs") && config_("configs").has("basePose"))
+    if(config_.has("configs") && config_("configs").has("basePose"))
     {
-      sva::PTransformd basePose = static_cast<sva::PTransformd>(config_("configs")("basePose"));
-      ctl().robot().posW(basePose);
-      ctl().realRobot().posW(basePose);
+      sva::PTransformd configBasePose = static_cast<sva::PTransformd>(config_("configs")("basePose"));
+      ctl().robot().posW(configBasePose);
+      ctl().realRobot().posW(configBasePose);
+    }
+    else if(ctl().datastore().has("MCC::LastBasePose"))
+    {
+      sva::PTransformd lastBasePose = ctl().datastore().get<sva::PTransformd>("MCC::LastBasePose");
+      ctl().robot().posW(lastBasePose);
+      ctl().realRobot().posW(lastBasePose);
     }
 
     // Reset managers

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -59,21 +59,6 @@ bool InitialState::run(mc_control::fsm::Controller &)
     stiffnessRatioFunc_ = std::make_shared<TrajColl::CubicInterpolator<double>>(
         std::map<double, double>{{ctl().t(), 0.0}, {ctl().t() + stiffnessInterpDuration, 1.0}});
 
-    // Initialize base pose of the robot
-    if(config_.has("configs") && config_("configs").has("basePose"))
-    {
-      sva::PTransformd configBasePose = static_cast<sva::PTransformd>(config_("configs")("basePose"));
-      ctl().robot().posW(configBasePose);
-      ctl().realRobot().posW(configBasePose);
-    }
-    else if(ctl().datastore().has("MCC::LastBasePose"))
-    {
-      sva::PTransformd lastBasePose = ctl().datastore().get<sva::PTransformd>("MCC::LastBasePose");
-      ctl().robot().posW(lastBasePose);
-      ctl().realRobot().posW(lastBasePose);
-      ctl().datastore().remove("MCC::LastBasePose"); // avoid accidental reuse of old base pose
-    }
-
     // Reset managers
     mc_rtc::Configuration initialContactsConfig;
     if(config_.has("configs") && config_("configs").has("initialContacts"))

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -59,6 +59,14 @@ bool InitialState::run(mc_control::fsm::Controller &)
     stiffnessRatioFunc_ = std::make_shared<TrajColl::CubicInterpolator<double>>(
         std::map<double, double>{{ctl().t(), 0.0}, {ctl().t() + stiffnessInterpDuration, 1.0}});
 
+    // Initialize base pose of the robot
+    if (config_.has("configs") && config_("configs").has("basePose"))
+    {
+      sva::PTransformd basePose = static_cast<sva::PTransformd>(config_("configs")("basePose"));
+      ctl().robot().posW(basePose);
+      ctl().realRobot().posW(basePose);
+    }
+
     // Reset managers
     mc_rtc::Configuration initialContactsConfig;
     if(config_.has("configs") && config_("configs").has("initialContacts"))

--- a/src/states/InitialState.cpp
+++ b/src/states/InitialState.cpp
@@ -71,6 +71,7 @@ bool InitialState::run(mc_control::fsm::Controller &)
       sva::PTransformd lastBasePose = ctl().datastore().get<sva::PTransformd>("MCC::LastBasePose");
       ctl().robot().posW(lastBasePose);
       ctl().realRobot().posW(lastBasePose);
+      ctl().datastore().remove("MCC::LastBasePose"); // avoid accidental reuse of old base pose
     }
 
     // Reset managers


### PR DESCRIPTION
When I start MCC after finishing another controller, the initial pose of the robot can be different from the one assumed in pre-defined motion in MCC. In addition, when I change a controller from MCC to other controllers and go back to MCC, the pose of the base can be modified by other controllers though the actual robot is in the same position.
To solve this initialization problem, I add option to save last pose of the base in datastore and overwrite pose of the base link in reset function. It also can be defined from yaml file as basePose, which is loaded when instantiating MCC.