### PR TITLE
Update global vertices after modifying contact by touchdown

### DIFF
--- a/include/MultiContactController/LimbManager.h
+++ b/include/MultiContactController/LimbManager.h
@@ -258,5 +258,8 @@ protected:
 
   //! Whether to require updating impedance gains for limb tasks
   bool requireImpGainUpdate_ = true;
+
+  //! Whether to require updating target pose for contact constraint
+  bool requireTouchDownPoseUpdate_ = false;
 };
 } // namespace MCC

--- a/src/LimbManager.cpp
+++ b/src/LimbManager.cpp
@@ -146,12 +146,6 @@ void LimbManager::update()
       {
         targetPose_ = swingTraj_->endPose_;
       }
-      else if(!config_.enableWrenchDistForTouchDownLimb)
-      {
-        // Vertices has already been updated when touchDown is detected
-        // if enableWrenchDistForTouchDownLimb is true
-        requireTouchDownPoseUpdate_ = true;
-      }
 
       targetVel_ = sva::MotionVecd::Zero();
       targetAccel_ = sva::MotionVecd::Zero();
@@ -253,10 +247,8 @@ void LimbManager::update()
     {
       touchDown_ = true;
 
-      if(config_.keepPoseForTouchDownLimb && config_.enableWrenchDistForTouchDownLimb)
+      if(config_.keepPoseForTouchDownLimb)
       {
-        // Vertices in contactCommand should be immediately updated by the current pose
-        // because the wrench distribution is activated just after touchDown
         requireTouchDownPoseUpdate_ = true;
       }
 

--- a/src/LimbManager.cpp
+++ b/src/LimbManager.cpp
@@ -282,7 +282,7 @@ void LimbManager::update()
 
   // Update currentContactCommand_ (this should be after setting swingTraj_)
   currentContactCommand_ = getContactCommand(ctl().t());
-  if (currentContactCommand_ && currentContactCommand_->constraint->type() != "Empty" && requireTouchDownPoseUpdate_)
+  if(currentContactCommand_ && currentContactCommand_->constraint->type() != "Empty" && requireTouchDownPoseUpdate_)
   {
     // Empty contact command does not have vertices for wrench distribution
     currentContactCommand_->constraint->updateGlobalVertices(targetPose_);

--- a/src/LimbManager.cpp
+++ b/src/LimbManager.cpp
@@ -66,6 +66,8 @@ void LimbManager::reset(const mc_rtc::Configuration & _constraintConfig)
     impGainType_ = "Uninitialized";
 
     requireImpGainUpdate_ = false;
+
+    requireTouchDownPoseUpdate_ = false;
   }
 
   contactCommandList_.clear();
@@ -143,6 +145,10 @@ void LimbManager::update()
       if(!(config_.keepPoseForTouchDownLimb && touchDown_))
       {
         targetPose_ = swingTraj_->endPose_;
+      }
+      else
+      {
+        requireTouchDownPoseUpdate_ = true;
       }
       targetVel_ = sva::MotionVecd::Zero();
       targetAccel_ = sva::MotionVecd::Zero();
@@ -274,6 +280,10 @@ void LimbManager::update()
 
   // Update currentContactCommand_ (this should be after setting swingTraj_)
   currentContactCommand_ = getContactCommand(ctl().t());
+  if (currentContactCommand_ && requireTouchDownPoseUpdate_) {
+    currentContactCommand_->constraint->updateGlobalVertices(targetPose_);
+    requireTouchDownPoseUpdate_ = false;
+  }
 
   // Update phase_
   if(currentSwingCommand_)


### PR DESCRIPTION
When `keepPoseForTouchDownLimb` is true, the pose of the limb at touchDown is preserved as contact pose but its vertices are not updated. This PR fixes this problem and update global vertices of the contact according to the new pose at touchDown.
This PR requires https://github.com/isri-aist/ForceControlCollection/pull/4.