### PR TITLE
Add option to wait for finishing nominal centroidal trajectory to exit ConfigMotionState

### DIFF
--- a/include/MultiContactController/CentroidalManager.h
+++ b/include/MultiContactController/CentroidalManager.h
@@ -229,6 +229,11 @@ public:
   /** \brief Set anchor frame. */
   void setAnchorFrame();
 
+  /** \brief Check whether reference CoM trajectory is completed at given time
+      \param t time
+  */
+  bool isFinished(const double t) const;
+
 protected:
   /** \brief Const accessor to the controller. */
   inline const MultiContactController & ctl() const

--- a/include/MultiContactController/states/ConfigMotionState.h
+++ b/include/MultiContactController/states/ConfigMotionState.h
@@ -25,5 +25,8 @@ protected:
 
   //! Task configuration list
   std::multimap<double, mc_rtc::Configuration> taskConfigList_;
+
+  //! Option to select whether this state should wait for finishing reference CoM trajectory or not
+  bool exitWhenCentroidalManagerFinished_ = false;
 };
 } // namespace MCC

--- a/src/CentroidalManager.cpp
+++ b/src/CentroidalManager.cpp
@@ -426,6 +426,15 @@ void CentroidalManager::setAnchorFrame()
   ctl().datastore().make_call(anchorName, [this](const mc_rbdyn::Robot & robot) { return calcAnchorFrame(robot); });
 }
 
+bool CentroidalManager::isFinished(const double t) const
+{
+  if(nominalCentroidalPoseList_.empty())
+  {
+    return true;
+  }
+  return t > nominalCentroidalPoseList_.rbegin()->first;
+}
+
 CentroidalManager::RefData CentroidalManager::calcRefData(double t) const
 {
   RefData refData;

--- a/src/states/ConfigMotionState.cpp
+++ b/src/states/ConfigMotionState.cpp
@@ -89,6 +89,11 @@ void ConfigMotionState::start(mc_control::fsm::Controller & _ctl)
     }
   }
 
+  if(config_.has("configs") && config_("configs").has("exitWhenCentroidalManagerFinished"))
+  {
+    exitWhenCentroidalManagerFinished_ = static_cast<bool>(config_("configs")("exitWhenCentroidalManagerFinished"));
+  }
+
   output("OK");
 }
 
@@ -161,7 +166,8 @@ bool ConfigMotionState::run(mc_control::fsm::Controller &)
     }
   }
 
-  return !ctl().limbManagerSet_->contactCommandStacked() && taskConfigList_.empty() && collisionConfigList_.empty();
+  return !ctl().limbManagerSet_->contactCommandStacked() && taskConfigList_.empty() && collisionConfigList_.empty()
+         && (!exitWhenCentroidalManagerFinished_ || ctl().centroidalManager_->isFinished(ctl().t()));
 }
 
 void ConfigMotionState::teardown(mc_control::fsm::Controller &) {}


### PR DESCRIPTION
Problem:
`ConfigMotionState::run()` does not check whether reference all CoM positions in CentroidalManager has been executed or not. This causes the failure in adding new reference CoM positions in the next ConfigMotion due to the time inconsistency as follows.
```
[error] [CentroidalManager] Ignore a nominal centroidal pose earlier than the last one: 40.44500000000208 < 42.84500000000079
```

Solution:
Add `exitWhenCentroidalManagerFinished_` flag to check whether all the reference CoM positions in CentroidalManager are updated at current timestep at the end of `ConfigMotionState::run()`.