### PR TITLE
[CNOID] Consider python version in cnoid file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,11 @@ jobs:
           catkin-test-args: --no-deps
           build-packages: multi_contact_controller
           test-packages: multi_contact_controller
+      - name: Check python
+        run: |
+          set -e
+          set -x
+          python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
       - name: Run simulation
         if: env.RUN_SIMULATION_STEPS == 'true'
         # https://github.com/jrl-umi3218/lipm_walking_controller/blob/b564d655388ae6a6725c504e5c74a62192e58c7c/.github/workflows/build.yml#L64-L92

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set(CMAKE_COLOR_DIAGNOSTICS ON)
 option(ENABLE_CNOID "Install Choreonoid files" ON)
 option(ENABLE_MUJOCO "Install MuJoCo files" OFF)
 option(INSTALL_DOCUMENTATION "Generate and install the documentation" OFF)
-option(ENABLE_PYTHON3 "Enable usagen of python3" OFF)
 
 include(cmake/base.cmake)
 project(multi_contact_controller LANGUAGES CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_COLOR_DIAGNOSTICS ON)
 option(ENABLE_CNOID "Install Choreonoid files" ON)
 option(ENABLE_MUJOCO "Install MuJoCo files" OFF)
 option(INSTALL_DOCUMENTATION "Generate and install the documentation" OFF)
+option(ENABLE_PYTHON3 "Enable usagen of python3" OFF)
 
 include(cmake/base.cmake)
 project(multi_contact_controller LANGUAGES CXX)

--- a/cnoid/project/CMakeLists.txt
+++ b/cnoid/project/CMakeLists.txt
@@ -1,7 +1,7 @@
 
-if(NOT CNOID_USE_PYTHON2)
+if(ENABLE_PYTHON3)
   execute_process(
-    COMMAND python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
+    COMMAND python3 -c "import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
     OUTPUT_VARIABLE PYTHON_VERSION
     RESULT_VARIABLE PYTHON_VERSION_SUCCESS
     OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -12,6 +12,15 @@ else()
     RESULT_VARIABLE PYTHON_VERSION_SUCCESS
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
+if(NOT PYTHON_VERSION_SUCCESS STREQUAL 0)
+  message("Python version failed to be detected")
+  execute_process(
+    COMMAND python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
+    OUTPUT_VARIABLE PYTHON_VERSION
+    RESULT_VARIABLE PYTHON_VERSION_SUCCESS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+message("-- Python version detected: ${PYTHON_VERSION}")
 
 set(MCC_CNOID_CONFIG_FILE_LIST
   rtc.conf.choreonoid

--- a/cnoid/project/CMakeLists.txt
+++ b/cnoid/project/CMakeLists.txt
@@ -1,3 +1,9 @@
+execute_process(
+  COMMAND python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
+  OUTPUT_VARIABLE PYTHON_VERSION
+  RESULT_VARIABLE PYTHON_VERSION_SUCCESS
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 set(MCC_CNOID_CONFIG_FILE_LIST
   rtc.conf.choreonoid
   robot.conf
@@ -5,6 +11,7 @@ set(MCC_CNOID_CONFIG_FILE_LIST
   PDcontroller.conf.choreonoid
   PDgains_sim.dat
 )
+
 foreach(CNOID_CONFIG_FILE IN LISTS MCC_CNOID_CONFIG_FILE_LIST)
   execute_process(COMMAND cmake -E create_symlink
     "${HRPSYSBASE_PREFIX}/share/hrpsys/samples/JVRC1/${CNOID_CONFIG_FILE}"

--- a/cnoid/project/CMakeLists.txt
+++ b/cnoid/project/CMakeLists.txt
@@ -1,8 +1,17 @@
-execute_process(
-  COMMAND python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
-  OUTPUT_VARIABLE PYTHON_VERSION
-  RESULT_VARIABLE PYTHON_VERSION_SUCCESS
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(NOT CNOID_USE_PYTHON2)
+  execute_process(
+    COMMAND python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
+    OUTPUT_VARIABLE PYTHON_VERSION
+    RESULT_VARIABLE PYTHON_VERSION_SUCCESS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+  execute_process(
+    COMMAND python2 -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
+    OUTPUT_VARIABLE PYTHON_VERSION
+    RESULT_VARIABLE PYTHON_VERSION_SUCCESS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 set(MCC_CNOID_CONFIG_FILE_LIST
   rtc.conf.choreonoid

--- a/cnoid/project/CMakeLists.txt
+++ b/cnoid/project/CMakeLists.txt
@@ -1,5 +1,4 @@
-
-if(ENABLE_PYTHON3)
+if(NOT ${CHOREONOID_USE_PYTHON2})
   execute_process(
     COMMAND python3 -c "import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
     OUTPUT_VARIABLE PYTHON_VERSION
@@ -13,7 +12,6 @@ else()
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 endif()
 if(NOT PYTHON_VERSION_SUCCESS STREQUAL 0)
-  message("Python version failed to be detected")
   execute_process(
     COMMAND python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
     OUTPUT_VARIABLE PYTHON_VERSION

--- a/cnoid/project/MCC_JVRC1_SampleField.in.cnoid
+++ b/cnoid/project/MCC_JVRC1_SampleField.in.cnoid
@@ -530,7 +530,7 @@ OpenRTM:
   "deleteUnmanagedRTCsOnStartingSimulation": true
 Python: 
   "moduleSearchPath": 
-    - @HRPSYSBASE_PREFIX@/lib/python2.7/dist-packages/hrpsys
+    - @HRPSYSBASE_PREFIX@/lib/python@PYTHON_VERSION@/dist-packages/hrpsys
 viewAreas: 
   - 
     type: embedded


### PR DESCRIPTION
In order to run choreonoid simulation, the python version used for choreonoid build must match the python version specified in .cnoid files. 

In order to get the python version used inside of choreonoid a PR has been created choreonoid/choreonoid#41. 

While this PR is not accepted, the following version of choreonoid should be used : 
* https://github.com/ThomasDuvinage/choreonoid

If you are using drcutil_superbuild, please consider using the following fork on ubuntu2204 branch :
* https://github.com/ThomasDuvinage/drcutil-superbuild/tree/ubuntu2204
